### PR TITLE
Add app priv dir reference

### DIFF
--- a/lib/mnemo.ex
+++ b/lib/mnemo.ex
@@ -177,7 +177,9 @@ defmodule Mnemo do
   end
 
   defp wordlist_stream(lang) do
-    "priv/#{lang}.txt"
+    :mnemo
+    |> Application.app_dir()
+    |> Path.join("priv/#{lang}.txt")
     |> File.stream!()
     |> Stream.with_index()
   end


### PR DESCRIPTION
When the application is included as a dependency, the path has to be defined via Application.app_dir(:mnemo) to make sure the resource file in the priv dir is found.